### PR TITLE
Correct a typo and speed up execution time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 /pom.xml
-*jar
+*.jar
 /lib
 /classes
 /native
 /.lein-failures
 /checkouts
 /.lein-deps-sum
+/target

--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -18,7 +18,7 @@ Add :main to your project.clj to specify the namespace that contains your
   (if (:main project)
     (let [opts (jvm-options project)
           target (file (:target-path project))
-          binfile (file target (:or (:executable-name project)
+          binfile (file target (or (:executable-name project)
                                     (str (:name project) "-" (:version project))))]
       (uberjar project)
       (println "Creating standalone executable:" (.getPath binfile))

--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -7,7 +7,7 @@
   (:import java.io.FileOutputStream))
 
 (defn- jvm-options [{:keys [jvm-opts name version] :or {jvm-opts []}}]
-  (join " " (conj jvm-opts (format "-D%s.version=%s" name version))))
+  (join " " (conj jvm-opts (format "-client -D%s.version=%s" name version))))
 
 (defn bin
   "Create a standalone console executable for your project.
@@ -23,8 +23,8 @@ Add :main to your project.clj to specify the namespace that contains your
       (uberjar project)
       (println "Creating standalone executable:" (.getPath binfile))
       (with-open [bin (FileOutputStream. binfile)]
-        (.write bin (.getBytes (format ":;exec java %s -jar $0 \"$@\"\n" opts)))
-        (.write bin (.getBytes (format "@echo off\r\njava %s -jar %%1 \"%%~f0\" %%*\r\ngoto :eof\r\n" opts)))
+        (.write bin (.getBytes (format ":;exec java %s -Xbootclasspath/a:$0 %s \"$@\"\n" opts (:main project))))
+        (.write bin (.getBytes (format "@echo off\r\njava %s -Xbootclasspath/a:%%1 %s \"%%~f0\" %%*\r\ngoto :eof\r\n" opts (:main project))))
         (copy (file (get-jar-filename project :uberjar)) bin))
       (.setExecutable binfile true))
     (println "Cannot create bin without :main namespace in project.clj")))


### PR DESCRIPTION
One change makes the `:executable-name` parameter work in `project.clj`.  The other favors `-Xbootclasspath/a` over `-jar` which shaves 1-3 seconds off startup time.

If you could release 0.2.1 with these changes I'd be most appreciative!
