### PR TITLE
Added ability to copy bin into a central location.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,6 +32,7 @@ You can also supply a `:bin` key like so:
 ## License
 
 Copyright (C) 2012 Anthony Grimes, Justin Balthrop
+
 Copyright (C) 2013 Jason Whitlark
 
 Distributed under the Eclipse Public License, the same as Clojure.

--- a/README.markdown
+++ b/README.markdown
@@ -22,10 +22,11 @@ needs to have `:gen-class` specified in its `ns` declaration).
 You can also supply a `:bin` key like so:
 
         :bin {:name "runme"
+              :bin-path "/home/user/bin"
               :bootclasspath true}
 
   * `:name`: Name the file something other than `project-version`
-  * `:bin-path`: Also copy the file into `bin-path`, which is presumably on you $PATH.
+  * `:bin-path`: If specified, also copy the file into `bin-path`, which is presumably on your $PATH.
   * `:bootclasspath`: Supply the uberjar to java via `-Xbootclasspath/a` instead of `-jar`.  Sometimes this can speed up execution, but may not work with all classloaders.
 
 ## License

--- a/README.markdown
+++ b/README.markdown
@@ -25,10 +25,12 @@ You can also supply a `:bin` key like so:
               :bootclasspath true}
 
   * `:name`: Name the file something other than `project-version`
+  * `:bin-path`: Also copy the file into `bin-path`, which is presumably on you $PATH.
   * `:bootclasspath`: Supply the uberjar to java via `-Xbootclasspath/a` instead of `-jar`.  Sometimes this can speed up execution, but may not work with all classloaders.
 
 ## License
 
 Copyright (C) 2012 Anthony Grimes, Justin Balthrop
+Copyright (C) 2013 Jason Whitlark
 
 Distributed under the Eclipse Public License, the same as Clojure.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-bin "0.3.0"
+(defproject lein-bin "0.3.1"
   :description "A leiningen plugin for generating standalone console executables for your project."
     :url "https://github.com/Raynes/lein-bin"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
This lets you specify {:bin {:bin-path "/home/me/bin"}}, so you can automatically copy the bin someplace on your $PATH.  Sort of emulates the way golang organizes it's bin files, which I've found handy.
