### PR TITLE
use `fs/expand-home` in bin-path

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,7 @@ needs to have `:gen-class` specified in its `ns` declaration).
 You can also supply a `:bin` key like so:
 
         :bin {:name "runme"
-              :bin-path "/home/user/bin"
+              :bin-path "~/bin"
               :bootclasspath true}
 
   * `:name`: Name the file something other than `project-version`

--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -29,7 +29,8 @@
 
 (defn ^:private copy-bin [project binfile]
   (when-let [bin-path (get-in project [:bin :bin-path])]
-    (let [new-binfile (fs/file bin-path (fs/base-name binfile))]
+    (let [bin-path (fs/expand-home bin-path)
+          new-binfile (fs/file bin-path (fs/base-name binfile))]
       (println "Copying binary to" bin-path)
       (fs/chmod "+x" (fs/copy+ binfile new-binfile)))))
 


### PR DESCRIPTION
handy to share `project.clj` among developers
