### PR TITLE
Default jvm settings to use "-client". If "-server" is specified, use "-...

### DIFF
--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -8,7 +8,9 @@
   (:import java.io.FileOutputStream))
 
 (defn- jvm-options [{:keys [jvm-opts name version] :or {jvm-opts []}}]
-  (join " " (conj jvm-opts (format "-D%s.version=%s" name version))))
+  (let [is-server (some #(= %1 "-server") jvm-opts)
+         client-opt (if is-server "-server" "-client")]
+    (join " " (distinct (conj jvm-opts client-opt (format "-D%s.version=%s" name version))))))
 
 (defn jar-preamble [flags]
   (format (str ":;exec java %s -jar $0 \"$@\"\n"


### PR DESCRIPTION
...server" instead.

Only write each jvm-opt once

``` clojure
(jvm-options {:jvm-opts ["-server"] :name "test" :version "0.0.1"})
;"-server -Dtest.version=0.0.1"
(jvm-options {:jvm-opts ["-client"] :name "test" :version "0.0.1"})
;"-client -Dtest.version=0.0.1"
(jvm-options {:jvm-opts ["-Xmx=3000m"] :name "test" :version "0.0.1"})
;"-Xmx=3000m -client -Dtest.version=0.0.1"
(jvm-options {:jvm-opts ["-Xmx=3000m" "-server"] :name "test" :version "0.0.1"})
;"-Xmx=3000m -server -Dtest.version=0.0.1"
```
