### PR TITLE
Pass main to uberjar...

### DIFF
--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -42,13 +42,13 @@
 Add :main to your project.clj to specify the namespace that contains your
 -main function."
   [project]
-  (if (:main project)
+  (if-let [main (:main project)]
     (let [opts (jvm-options project)
           target (fs/file (:target-path project))
           binfile (fs/file target
                            (or (get-in project [:bin :name])
                                (str (:name project) "-" (:version project))))
-          jarfile (uberjar project)]
+          jarfile (uberjar project main)]
       (println "Creating standalone executable:" (str binfile))
       (io/make-parents binfile)
       (with-open [bin (FileOutputStream. binfile)]


### PR DESCRIPTION
... to enable building binaries for profiles that override the main class.

This allows lein-bin to work for profiles that override the main class:

```
:other-main {:main ns.other-main
             :bin {:name "other-main"}}
```

`lein with-profiles +other-main bin` will build the binary that executes `ns.other-main`.
