### PR TITLE
Improve quoting in the preamble.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-bin "0.3.4"
+(defproject lein-bin "0.3.6-SNAPSHOT"
   :description "A leiningen plugin for generating standalone console executables for your project."
   :url "https://github.com/Raynes/lein-bin"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -13,14 +13,15 @@
     (join " " (distinct (conj jvm-opts client-opt (format "-D%s.version=%s" name version))))))
 
 (defn jar-preamble [flags]
-  (format (str ":;exec java %s -jar $0 \"$@\"\n"
-               "@echo off\r\njava %s -jar %%1 \"%%~f0\" %%*\r\ngoto :eof\r\n")
+  (format (str ":;exec java %s -jar \"$0\" \"$@\"\n"
+               "@java %s -jar \"%%~f0\" %%*\r\n"
+               "@goto :eof\r\n")
           flags flags))
 
 (defn boot-preamble [flags main]
-  (format (str ":;exec java %s -Xbootclasspath/a:$0 %s \"$@\"\n"
-               "@echo off\r\njava %s -Xbootclasspath/a:%%1 %s "
-               "\"%%~f0\" %%*\r\ngoto :eof\r\n")
+  (format (str ":;exec java %s -Xbootclasspath/a:\"$0\" %s \"$@\"\n"
+               "@java %s -Xbootclasspath/a:\"%%~f0\" %s %%*\r\n"
+               "@goto :eof\r\n")
           flags main flags main))
 
 (defn write-jar-preamble! [out flags]


### PR DESCRIPTION
On Unix, use double quotes around "$0" to protect against
the case where the script may have spaces in its name.

On Windows, the name of the batch file is in variable %0,
available as "%~f0" for a quoted fully-qualified path.
The variable %1 is the first commandline arg, and is not
the right variable for -jar or -Xbootclasspath . This patch
puts "%~f0" into the right places and removes %1 as needed.

Enhancement: for such a short preamble, putting "@echo off"
is minor overkill - it is simpler to just have a "@" at
the start of the "java" and "goto" lines.
