### PR TITLE
add support for jvm-opts overrides and environment variables

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,11 +23,18 @@ You can also supply a `:bin` key like so:
 
         :bin {:name "runme"
               :bin-path "~/bin"
-              :bootclasspath true}
+              :bootclasspath true
+              :jvm-opts ["-server" "$JVM_OPTS" "-Dfile.encoding=utf-8"]}
 
   * `:name`: Name the file something other than `project-version`
-  * `:bin-path`: If specified, also copy the file into `bin-path`, which is presumably on your $PATH.
-  * `:bootclasspath`: Supply the uberjar to java via `-Xbootclasspath/a` instead of `-jar`.  Sometimes this can speed up execution, but may not work with all classloaders.
+  * `:bin-path`: If specified, also copy the file into `bin-path`,
+    which is presumably on your $PATH.
+  * `:bootclasspath`: Supply the uberjar to java via
+    `-Xbootclasspath/a` instead of `-jar`.  Sometimes this can speed
+    up execution, but may not work with all classloaders.
+  * `:jvm-opts`: If specified, supply the Java options to be used in
+    the executable jar. When present it overrides the project's
+    `:jvm-opts`. It support environment variables as well.
 
 ## License
 

--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -7,21 +7,34 @@
             [clojure.java.io :as io])
   (:import java.io.FileOutputStream))
 
-(defn- jvm-options [{:keys [jvm-opts name version] :or {jvm-opts []}}]
+(defn- jvm-options [{:keys [name version]} jvm-opts]
   (let [is-server (some #(= %1 "-server") jvm-opts)
          client-opt (if is-server "-server" "-client")]
-    (join " " (distinct (conj jvm-opts client-opt (format "-D%s.version=%s" name version))))))
+    (distinct (conj jvm-opts client-opt (format "-D%s.version=%s" name version)))))
+
+
+(defn- sanitize-jvm-opts-for-win
+  "turns linux style vars \"$FOO\" into win style \"%FOO\"."
+  [opts]
+  (map
+   (fn [^String o]
+     (when o
+       (.replaceAll o "\\$([a-zA-Z0-9_]+)" "%$1%")))
+   opts))
+
 
 (defn jar-preamble [flags]
   (format (str ":;exec java %s -jar $0 \"$@\"\n"
                "@echo off\r\njava %s -jar %%1 \"%%~f0\" %%*\r\ngoto :eof\r\n")
-          flags flags))
+          (join " " flags)
+          (join " " (sanitize-jvm-opts-for-win flags))))
 
 (defn boot-preamble [flags main]
   (format (str ":;exec java %s -Xbootclasspath/a:$0 %s \"$@\"\n"
                "@echo off\r\njava %s -Xbootclasspath/a:%%1 %s "
                "\"%%~f0\" %%*\r\ngoto :eof\r\n")
-          flags main flags main))
+          (join " " flags) main
+          (join (sanitize-jvm-opts-for-win flags)) main))
 
 (defn write-jar-preamble! [out flags]
   (.write out (.getBytes (jar-preamble flags))))
@@ -43,11 +56,15 @@ Add :main to your project.clj to specify the namespace that contains your
 -main function."
   [project]
   (if (:main project)
-    (let [opts (jvm-options project)
-          target (fs/file (:target-path project))
+    (let [target  (fs/file (:target-path project))
           binfile (fs/file target
                            (or (get-in project [:bin :name])
-                               (str (:name project) "-" (:version project))))
+                              (str (:name project) "-" (:version project))))
+
+          jvm-opts     (:jvm-opts project)
+          bin-jvm-opts (get-in project [:bin :jvm-opts])
+          opts         (jvm-options project (or bin-jvm-opts jvm-opts []))
+
           jarfile (uberjar project)]
       (println "Creating standalone executable:" (str binfile))
       (io/make-parents binfile)


### PR DESCRIPTION
This enables to specify a set of `:jvm-opts` which will be baked in the executable jar.
The options you want to bake into the executable might be different than those ones
you use for the development (lein repl).
In addition to this it supports environment variables such as `$JVM_OPTS` which currently aren't in leiningen and it correctly convert to `%JVM_OPTS%` for windows platform

example:

```
    :jvm-opts ["-Xmx2g"]
    :bin {:name "foo"
          :jvm-opts ["-server" "$JVM_OPTS" "-Dfile.encoding=utf-8"]}
```

the output

```
$ head -3 ./target/foo
:;exec java -server $JVM_OPTS -Dfile.encoding=utf-8 -Dfoo.version=0.5.7 -jar $0 "$@"
@echo off
java -server %JVM_OPTS% -Dfile.encoding=utf-8 -Dfoo.version=0.5.7 -jar %1 "%~f0" %*
```
