### PR TITLE
adding jar offset rewriting and capability to use custom preambles

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,8 @@
 # lein-bin
 
+[![Current Version](https://img.shields.io/clojars/v/lein-bin.svg)](https://clojars.org/lein-bin)
+[![License](https://img.shields.io/badge/License-EPL%201.0-green.svg)](https://opensource.org/licenses/EPL-1.0)
+
 A Leiningen plugin for producing standalone console executables that
 work on OS X, Linux, and Windows.
 
@@ -28,6 +31,44 @@ You can also supply a `:bin` key like so:
   * `:name`: Name the file something other than `project-version`
   * `:bin-path`: If specified, also copy the file into `bin-path`, which is presumably on your $PATH.
   * `:bootclasspath`: Supply the uberjar to java via `-Xbootclasspath/a` instead of `-jar`.  Sometimes this can speed up execution, but may not work with all classloaders.
+
+## Advanced Usage
+Under the hood this plugin adds a snippet of text to the beginning of your uber jar. Assuming you rewrite all the offsets in the zip file (or jar file in this case) meta data, the resulting jar file is still considered valid by the [zip file specification](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) and as a consequence by any sane zip implementation including programs like unzip and perhaps more significantly by java itself. 
+
+So we add a snippet of text to the beginning of the uber jar, rewrite the zip meta data offsets and then make the uber jar executable. Now when you try to directly execute the uber jar, the operating system will try to run the prelude snippet of text we added to the file. If this prelude snippet is written in a way such that it is considered a valid shell/bat script on both windows and linux/osx, then we have just created ourselves a true executable jar file without the need to invoke `java -jar uber.jar`. 
+
+So to get this working we need to write a "script" which works on both windows and *nix. This is a science unto itself, but suffice to say that it is possible. The default sample script inserted looks as follows: 
+
+```
+:;exec java %s -jar $0 "$@"
+@echo off\r\njava %s -jar %%1 \"%%~f0\" %%*\r\ngoto :eof
+```
+
+where:
+
+* on windows machines only the second line is executed and the first one is seen as a comment
+* on *nix machines the first line is executed and since the `exec` command relinquishes control from the current process and replaces it with the `java -jar ...` one, the second line is never executed
+
+For advanced usage or to take advantage of startup accelerators such as [drip](https://github.com/ninjudd/drip), you can include a custom preamble script in place of the above snippet by using the `:preamble-script` key like so: 
+
+```clojure
+:bin {:name "runme"
+      :bin-path "~/bin"
+      :preamble-script "custom-preample.txt"}
+```
+
+an example preamble for using drip if drip exists and otherwise fall back to java could look as follows: 
+
+```bash
+:; hash drip  >/dev/null 2>&1 # make sure the command call on the next line has an up to date worldview
+:;if command -v drip >/dev/null 2>&1 ; then CMD=drip; else CMD=java; fi
+:;$CMD -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:-OmitStackTraceInFastThrow -client -Xbootclasspath/a:"$0" myapp.core "$@"; exit $?
+@echo off
+java -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:-OmitStackTraceInFastThrow -client -Xbootclasspath/a:%1 myapp.core "%~f0" %*
+goto :eof
+```
+
+where `myapp.core` is the name of the main class of your program. 
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-bin "0.3.5"
+(defproject lein-bin "0.3.6-SNAPSHOT"
   :description "A leiningen plugin for generating standalone console executables for your project."
   :url "https://github.com/Raynes/lein-bin"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[me.raynes/fs "1.4.0"]
-                 [clj-zip-meta/clj-zip-meta "0.1.1" :exclusions [org.clojure/clojure]]
-                 [org.clojure/core.incubator "0.1.4"]]
+                 [clj-zip-meta/clj-zip-meta "0.1.1" :exclusions [org.clojure/clojure]]]
+                 ;;[org.clojure/core.incubator "0.1.4"]]
   :eval-in-leiningen true)

--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[me.raynes/fs "1.4.0"]
-                 [clj-zip-meta/clj-zip-meta "0.1.1" :exclusions [org.clojure/clojure]]]
+                 [clj-zip-meta/clj-zip-meta "0.1.2-SNAPSHOT" :exclusions [org.clojure/clojure]]]
   :eval-in-leiningen true)

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,9 @@
-(defproject lein-bin "0.3.4"
+(defproject lein-bin "0.3.5"
   :description "A leiningen plugin for generating standalone console executables for your project."
   :url "https://github.com/Raynes/lein-bin"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[me.raynes/fs "1.4.0"]]
+  :dependencies [[me.raynes/fs "1.4.0"]
+                 [clj-zip-meta/clj-zip-meta "0.1.1" :exclusions [org.clojure/clojure]]
+                 [org.clojure/core.incubator "0.1.4"]]
   :eval-in-leiningen true)

--- a/project.clj
+++ b/project.clj
@@ -5,5 +5,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[me.raynes/fs "1.4.0"]
                  [clj-zip-meta/clj-zip-meta "0.1.1" :exclusions [org.clojure/clojure]]]
-                 ;;[org.clojure/core.incubator "0.1.4"]]
   :eval-in-leiningen true)

--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -4,7 +4,8 @@
             [leiningen.jar :refer [get-jar-filename]]
             [leiningen.uberjar :refer [uberjar]]
             [me.raynes.fs :as fs]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [clj-zip-meta.core :as zm])
   (:import java.io.FileOutputStream))
 
 (defn- jvm-options [{:keys [jvm-opts name version] :or {jvm-opts []}}]
@@ -29,6 +30,16 @@
 (defn write-boot-preamble! [out flags main]
   (.write out (.getBytes (boot-preamble flags main))))
 
+(defn write-custom-preamble! [project out flags]
+  (let [path (get-in project [:bin :preamble-script])
+        file (clojure.java.io/as-file path)]
+    (if (.exists file)
+      (do
+        (println "> writing custom preamble...")
+        (io/copy file out))
+      (println "> ERROR: custom preamble file" path "not found!"))))
+
+
 (defn ^:private copy-bin [project binfile]
   (when-let [bin-path (get-in project [:bin :bin-path])]
     (let [bin-path (fs/expand-home bin-path)
@@ -52,10 +63,13 @@ Add :main to your project.clj to specify the namespace that contains your
       (println "Creating standalone executable:" (str binfile))
       (io/make-parents binfile)
       (with-open [bin (FileOutputStream. binfile)]
-        (if (get-in project [:bin :bootclasspath])
-          (write-boot-preamble! bin opts (:main project))
-          (write-jar-preamble! bin opts))
+        (condp 
+          (get-in project [:bin :preamble-script]) (write-custom-preamble! project bin opts)
+          (get-in project [:bin :bootclasspath])   (write-boot-preamble! bin opts (:main project))
+          :else (write-jar-preamble! bin opts))
         (io/copy (fs/file jarfile) bin))
       (fs/chmod "+x" binfile)
-      (copy-bin project binfile))
+      (copy-bin project binfile)
+      (println "> re-aligning zip offsets...")
+      (zm/repair-zip-with-preamble-bytes binfile))
     (println "Cannot create bin without :main namespace in project.clj")))

--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -65,8 +65,8 @@ Add :main to your project.clj to specify the namespace that contains your
       (with-open [bin (FileOutputStream. binfile)]
         (cond
           (get-in project [:bin :preamble-script]) (write-custom-preamble! project bin opts)
-          (get-in project [:bin :bootclasspath]) (write-boot-preamble! bin opts (:main project))
-          :else (write-jar-preamble! bin opts))
+          (get-in project [:bin :bootclasspath])   (write-boot-preamble! bin opts (:main project))
+          :else                                    (write-jar-preamble! bin opts))
         (io/copy (fs/file jarfile) bin))
       (fs/chmod "+x" binfile)
       (copy-bin project binfile)

--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -54,8 +54,8 @@ Add :main to your project.clj to specify the namespace that contains your
 -main function."
   [project]
   (if (:main project)
-    (let [opts (jvm-options project)
-          target (fs/file (:target-path project))
+    (let [opts    (jvm-options project)
+          target  (fs/file (:target-path project))
           binfile (fs/file target
                            (or (get-in project [:bin :name])
                                (str (:name project) "-" (:version project))))
@@ -63,9 +63,9 @@ Add :main to your project.clj to specify the namespace that contains your
       (println "Creating standalone executable:" (str binfile))
       (io/make-parents binfile)
       (with-open [bin (FileOutputStream. binfile)]
-        (condp 
+        (cond
           (get-in project [:bin :preamble-script]) (write-custom-preamble! project bin opts)
-          (get-in project [:bin :bootclasspath])   (write-boot-preamble! bin opts (:main project))
+          (get-in project [:bin :bootclasspath]) (write-boot-preamble! bin opts (:main project))
           :else (write-jar-preamble! bin opts))
         (io/copy (fs/file jarfile) bin))
       (fs/chmod "+x" binfile)


### PR DESCRIPTION
First of all, thank you for this library. I have been looking for a way to do this for ages and this really solves the problem in an elegant and once-and-for-all way. 

With that being said, the current state of this library still left me with two items missing from my wish list of perfection: 

* jar file meta data offsets. The current method of just appending text to the front of the jar file leaves the jar file integrity compromised as none of the jar/zip internal offsets are accurate after the prepend. We would like to rewrite the resulting jar file zip meta data offsets so that tools such as unzip would still consider the zip file valid (as in with valid offsets. Try adding a longer preamble script with the current implementation and then either executing it with java or just running `unzip -l ` on the resulting jar). 
* the ability to use custom preamble scripts to be able to optionally support launch accelerators such as drip. Or whatever insanity users of this library come up with. 

I'm somewhat new to clojure and solving this problem led me down quite a journey. In (not so) short:

* look around and realize there is no library on the jvm to read the zip file meta data as specified by the [zip file specification](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT). I'm not talking about java's ZipFile and friends which only deal with entries and have no concept of things like central directories or local headers as defined in the zip file specification. 
* be dissappointed and meditate over the un-reality of the fact that the base distribution unit of all java appliactions is jar files and we have nothing that can actually read them properly. 
* pick yourself up and boldly charge into the frey. Zip files. I mean...how hard can it be?
* figure out which binary format library to use in clojure. The top contenders seemed to be [octet](https://github.com/funcool/octet) and [buffy](https://github.com/clojurewerkz/buffy), but there are others. Try them all out and try to implement zip files in them. 
* realize that none of them solve the problem the way I needed to. As none of them solve the problem out of the box, settle for the simplicity of octet. It has a clean and terse specification dsl. 
* understand the zip file format and how the offset calculations work and why adding a prelude without fixing the offsets breaks the zip file. 
* realize that octet was missing support for the custom length field pattern (ref lengths, see the linked octet pull request for details) used in the zip file specification and it was thus not possible to write a spec in octet for the zip file format. Could not get buffy to work either. Count to ten. 
* write a [somewhat extensive pull request](https://github.com/funcool/octet/pull/11) to octet adding the required support for reference length fields. 
* wait for pull request to be accepted. Thank you @niwinz for accepting it. 
* with the proper tooling for writing a specification for zip files finally in place in octet, write the library missing from the jvm: [clj-zip-meta](https://github.com/mbjarland/clj-zip-meta). Yay, we can now read zip/jar file meta data and have it returned as clojure data structures. 
* iterate...publish to clojars. 
* make changes to this library now using the ability to rewrite zip offsets using the newly written lib. Also  add custom preamble support. 
* fight with command line parsing issues for an eternity to get optional (as in, use if installed) drip support working.
* create this pull request

apologies for the rambling. It was some journey and I would like to thank the writers of this library for writing something so good that it was worth the above trouble to improve on. 

If you deem this change acceptable, great. If not, this still solves my local problem so again, many thanks for this library. 
