### PR TITLE
Change target path to target

### DIFF
--- a/src/leiningen/bin.clj
+++ b/src/leiningen/bin.clj
@@ -44,7 +44,7 @@ Add :main to your project.clj to specify the namespace that contains your
   [project]
   (if (:main project)
     (let [opts (jvm-options project)
-          target (fs/file (:target-path project))
+          target (fs/file (:target project))
           binfile (fs/file target
                            (or (get-in project [:bin :name])
                                (str (:name project) "-" (:version project))))


### PR DESCRIPTION
`:target-path` points to the path where targets are stored, but the file to be
modified will be the `:target` jar of the project build, which will include the
name of the build target and its path.

fixes #27